### PR TITLE
Re-add indentation module

### DIFF
--- a/apps/sourcer/test/sourcer_indent_tests.erl
+++ b/apps/sourcer/test/sourcer_indent_tests.erl
@@ -1,0 +1,46 @@
+%%
+%%
+-module(sourcer_indent_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+indent_test_() ->
+    Dir = filename:dirname(code:which(?MODULE)) ++ "/" ++ ?MODULE_STRING ++ "_data",
+    OrigFs = filelib:wildcard(Dir ++ "/*"),
+    io:format("Dir: ~s~nFs: ~p~n", [Dir, OrigFs]),
+    Fs = [{File, unindent(File)} || File <- OrigFs,
+                                    filename:extension(File) =:= ""],
+    %% Indent = fun emacs/1,
+    Indent = fun sourcerer/1,
+    [Indent(File) || {_, File} <- Fs],
+    Res = [diff(Orig, File) || {Orig, File} <- Fs],
+    [file:delete(File) || {ok, File} <- Res],       %% Cleanup
+    Failed = [Fail || {fail, Fail} <- Res],
+    ?_assertEqual([],Failed).
+
+unindent(Input) ->
+    Output = Input ++ ".erl",
+    {ok, Bin} = file:read_file(Input),
+    Lines0 = string:split(Bin, "\n", all),
+    Lines = [string:trim(Line, leading, [$\s,$\t]) || Line <- Lines0],
+    %% io:format("File: ~s lines: ~w~n", [Input, length(Lines0)]),
+    %% [io:format("~s~n", [L]) || L <- Lines],
+    ok = file:write_file(Output, lists:join("\n", Lines)),
+    Output.
+
+diff(Orig, File) ->
+    case os:cmd(["diff ", Orig, " ", File]) of
+        "" -> {ok, File};
+        Diff ->
+            io:format(user, "Fail: ~s vs ~s~n~s~n~n",[Orig, File, Diff]),
+            {fail, File}
+    end.
+
+sourcerer(File) ->
+    io:format("* Indenting: ~s *~n",[File]),
+    {ok, Bin} = file:read_file(File),
+    Src = unicode:characters_to_list(Bin),
+    Indented = sourcer_indent:lines(Src),
+    file:write_file(File, unicode:characters_to_binary(Indented)).
+
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/comments
+++ b/apps/sourcer/test/sourcer_indent_tests_data/comments
@@ -1,0 +1,25 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% 3 comment chars: always left indented
+%%% 2 comment chars: Context indented
+%%% 1 comment char: Rigth indented
+
+%%% left
+%% context dependent
+                                                % rigth
+
+func() ->
+%%% left
+    %% context dependent
+                                                % right indented
+    case get(foo) of
+        undefined ->
+            %% Testing indention
+            ok;
+        %% Catch all
+        Other ->
+            Other
+    end,
+    ok.
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/comprehensions
+++ b/apps/sourcer/test/sourcer_indent_tests_data/comprehensions
@@ -1,0 +1,47 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of comprehensions
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+list() ->
+    %% I don't have a good idea how we want to handle this
+    %% but they are here to show how they are indented today.
+    Result1 = [X ||
+                  #record{a=X} <- lists:seq(1, 10),
+                  true = (X rem 2)
+              ],
+    Result2 = [X || <<X:32,_:32>> <= <<0:512>>,
+                    true = (X rem 2)
+              ],
+    Res = [ func(X,
+                 arg2)
+            ||
+              #record{a=X} <- lists:seq(1, 10),
+              true = (X rem 2)
+          ],
+    Result1.
+
+binary(B) ->
+    Binary1 = << <<X:8>> ||
+                  #record{a=X} <- lists:seq(1, 10),
+                  true = (X rem 2)
+              >>,
+
+    Binary2 = << <<X:8>> || <<X:32,_:32>> <= <<0:512>>,
+                            true = (X rem 2)
+              >>,
+
+    Bin3 = <<
+             <<
+               X:8,
+               34:8
+             >>
+             || <<X:32,_:32>> <= <<0:512>>,
+                true = (X rem 2)
+           >>,
+    ok.

--- a/apps/sourcer/test/sourcer_indent_tests_data/funcs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/funcs
@@ -1,0 +1,174 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Function (and funs) indentation
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+-export([
+         func1/0,
+         func2/0,
+         a_function_with_a_very_very_long_name/0,
+         when1/2
+        ]).
+
+-compile([nowarn_unused_functions,
+          {inline, [
+                    func2/2,
+                    func3/2
+                   ]
+          }
+         ]).
+
+func1() ->
+    basic.
+
+func2(A1,
+      A2) ->
+    ok.
+
+func3(
+  A1,
+  A2
+ ) ->
+    ok.
+
+%% Okeefe style
+func4(A1
+     ,A2
+     ,A3
+     ) ->
+    ok.
+
+func5(
+  A41
+ ,A42) ->
+    ok.
+
+a_function_with_a_very_very_long_name() ->
+    A00 = #record{
+             field1=1,
+             field2=1
+            },
+    A00.
+
+when1(W1, W2)
+  when is_number(W1),
+       is_number(W2) ->
+    ok.
+
+when2(W1,W2,W3) when
+      W1 > W2,
+      W2 > W3 ->
+    ok.
+
+when3(W1,W2,W3) when
+      W1 > W2,
+      W2 > W3
+      ->
+    ok.
+
+when4(W1,W2,W3)
+  when
+      W1 > W2,
+      W2 > W3 ->
+    ok.
+
+match1({[H|T],
+        Other},
+       M1A2) ->
+    ok.
+
+match2(
+  {
+   [H|T],
+   Other
+  },
+  M2A2
+ ) ->
+    ok.
+
+match3({
+        M3A1,
+        [
+         H |
+         T
+        ],
+        Other
+       },
+       M3A2
+      ) ->
+    ok.
+
+match4(<<
+         M4A:8,
+         M4B:16/unsigned-integer,
+         _/binary
+       >>,
+       M4C) ->
+    ok.
+
+match5(M5A,
+       #record{
+          b=M5B,
+          c=M5C
+         }
+      ) ->
+    ok.
+
+match6(M6A,
+       #{key6a := a6,
+         key6b := b6
+        }) ->
+    ok.
+
+funs(1)
+  when
+      X ->
+    %% Changed fun to one indention level
+    %% 'when' and several clause forces a depth of '4'
+    Var = spawn(fun(X, _)
+                      when X == 2;
+                           X > 10 ->
+                        hello,
+                        case Hello() of
+                            true when is_atom(X) ->
+                                foo;
+                            false ->
+                                bar
+                        end;
+                   (Foo) when is_atom(Foo),
+                              is_integer(X) ->
+                        X = 6 * 45,
+                        Y = true andalso
+                            kalle
+                end),
+    Var;
+funs(2) ->
+    %% check EEP37 named funs
+    Fn1 = fun
+              Factory(N) when
+                    N > 0 ->
+                  F = Fact(N-1),
+                  N * F;
+              Factory(0) ->
+                  1
+          end,
+    Fn1;
+funs(3) ->
+    %% check anonymous funs too
+    Fn2 = fun(0) ->
+                  1;
+             (N) ->
+                  N
+          end,
+    ok;
+funs(4) ->
+    X = lists:foldr(fun(M) ->
+                            <<M/binary, " ">>
+                    end, [], Z),
+    A = <<X/binary, 0:8>>,
+    A.

--- a/apps/sourcer/test/sourcer_indent_tests_data/highlight
+++ b/apps/sourcer/test/sourcer_indent_tests_data/highlight
@@ -1,0 +1,78 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Open this file in your editor and manually check the colors of
+%%% different types and calls and builtin words
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+
+highlighting(X)			  % Function definitions should be highlighted
+  when is_integer(X) ->	          % and so should `when' and `is_integer' be
+    %% Highlighting
+    %% Various characters (we keep an `atom' after to see that highlighting ends)
+    $a,atom,			  % Characters should be marked
+    "string",atom,		  % and strings
+    'asdasd',atom,		  % quote should be atoms??
+    'VaV',atom,
+    'aVa',atom,
+    '\'atom',atom,
+    'atom\'',atom,
+    'at\'om',atom,
+    '#1',atom,
+
+    $", atom,					% atom should be ok
+    $', atom,
+
+    "string$", atom,  "string$", atom,  		% currently buggy I know...
+    "string\$", atom,   				% workaround for bug above
+
+    "char $in string", atom,
+
+    'atom$', atom,  'atom$', atom,
+    'atom\$', atom,
+
+    'char $in atom', atom,
+
+    $[, ${, $\\, atom,
+    ?MACRO_1,
+    ?MACRO_2(foo),
+
+    %% Numerical constants
+    16#DD,					% Should not be highlighted
+    32#dd,					% Should not be highlighted
+    32#ddAB,				        % Should not be highlighted
+    32#101,				        % Should not be highlighted
+    32#ABTR,				        % Should not be highlighted
+
+    %% Variables
+    Variables = lists:foo(),
+    _Variables = lists:foo(),
+    AppSpec = Xyz/2,
+    Module42 = Xyz(foo, bar),
+    Module:foo(),
+    _Module:foo(),				%
+    FooÅÅ = lists:reverse([tl,hd,tl,hd]),	%  Should highlight FooÅÅ
+    _FooÅÅ = 42,				%  Should highlight _FooÅÅ
+
+    %% Bifs
+    erlang:registered(),
+    registered(),
+    hd(tl(tl(hd([a,b,c])))),
+    erlang:anything(lists),
+    %% Guards
+    is_atom(foo), is_float(2.3), is_integer(32), is_number(4323.3),
+    is_function(Fun), is_pid(self()),
+    not_a_guard:is_list([]),
+    %% Other Types
+
+    atom,			  % not (currently) hightlighted
+    234234,
+    234.43,
+
+    [list, are, not, higlighted],
+    {nor, is, tuple},
+    ok.

--- a/apps/sourcer/test/sourcer_indent_tests_data/icr
+++ b/apps/sourcer/test/sourcer_indent_tests_data/icr
@@ -1,0 +1,157 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of if case receive statements
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+indent_if(1, Z) ->
+    %% If
+    if Z >= 0 ->
+            X = 43 div Z,
+            X;
+       Z =< 10 ->
+            X = 43 div Z,
+            X;
+       Z == 5 orelse
+       Z == 7 ->
+            X = 43 div Z,
+            X;
+       is_number(Z),
+       Z < 32 ->
+            Z;
+       is_number(Z);
+       Z < 32 ->
+            Z * 32;
+       true ->
+            if_works
+    end;
+indent_if(2, Z) ->
+    %% If
+    if
+        Z >= 0 ->
+            X = 43 div Z,
+            X
+      ; Z =< 10 ->
+            43 div Z
+      ; Z == 5 orelse
+        Z == 7 ->
+            X = 43 div Z,
+            X
+      ; is_number(Z),
+        Z < 32 ->
+            Z
+      ; true ->
+            if_works
+    end.
+
+indent_case(1, Z) ->
+    %% Case
+    case {Z, foo, bar} of
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X);
+        {Z,_,_}	when
+              Z =:= 42 ->                       % line should be indented as a when
+            X = 43 div 4,
+            foo(X);
+        {Z,_,_}
+          when   Z < 10 orelse
+              Z =:= foo ->			% emacs differ see below
+            X = 43 div 4,
+            Bool = Z < 5 orelse                 % Emacs Binary op args align differently after when
+                Z =:= foo,                      % and elsewhere ???
+            foo(X);
+        {Z,_,_}
+          when					% when should be indented
+              Z < 10				% and the guards should follow when
+              andalso				% unsure about how though
+              true ->
+            X = 43 div 4,
+            foo(X)
+    end;
+indent_case(2, Z) ->
+    %% Case
+    case {Z, foo, bar} of
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}	when
+              Z =:= 42 ->                       % line should be indented as a when
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}
+          when Z < 10 ->			% when should be indented
+            X = 43 div 4,
+            foo(X)
+      ; {Z,_,_}
+          when					% when should be indented
+              Z < 10				% and the guards should follow when
+              andalso				% unsure about how though
+              true ->
+            X = 43 div 4,
+            foo(X)
+    end.
+
+indent_begin(Z) ->
+    %% Begin
+    begin
+        sune,
+        Z = 74234 +
+            foo(8456) +
+            345 div 43,
+        Foo = begin
+                  ok,
+                  foo(234),
+                  begin
+                      io:format("Down here\n")
+                  end
+              end,
+        {Foo,
+         bar}
+    end.
+
+indent_receive(1) ->
+    %% receive
+    receive
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X)
+      ; Z ->
+            X = 43 div 4,
+            foo(X)
+    end,
+    ok;
+indent_receive(2) ->
+    receive
+        {Z,_,_} ->
+            X = 43 div 4,
+            foo(X);
+        Z 					% added clause
+          when Z =:= 1 ->			% This line should be indented by 2
+            X = 43 div 4,
+            foo(X);
+        Z when					% added clause
+              Z =:= 2 ->			% This line should be indented by 2
+            X = 43 div 4,
+            foo(X);
+        Z ->
+            X = 43 div 4,
+            foo(X)
+    after infinity ->
+            foo(X),
+            asd(X),
+            5*43
+    end,
+    ok;
+indent_receive() ->
+    receive
+    after 10 ->
+            foo(X),
+            asd(X),
+            5*43
+    end,
+    ok.

--- a/apps/sourcer/test/sourcer_indent_tests_data/macros
+++ b/apps/sourcer/test/sourcer_indent_tests_data/macros
@@ -1,0 +1,31 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Macros should be indented as code
+
+-define(M0, ok).
+
+-define(M1,
+        case X of
+            undefined -> error;
+            _ -> ok
+        end).
+
+-define(M2(M2A1,
+           M2A2),
+        func(M2A1,
+             M2A2)
+       ).
+
+-define(
+   M3,
+   undefined
+  ).
+
+-ifdef(DEBUG).
+-define(LOG,
+        logger:log(?MODULE,?LINE)
+       ).
+-else().
+-define(LOG, ok).
+-endif().

--- a/apps/sourcer/test/sourcer_indent_tests_data/records
+++ b/apps/sourcer/test/sourcer_indent_tests_data/records
@@ -1,0 +1,35 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%% Test that records are indented correctly
+
+-record(record0,
+        {
+         r0a,
+         r0b,
+         r0c
+        }).
+
+-record(record1, {r1a,
+                  r1b,
+                  r1c
+                 }).
+
+-record(record2, {
+                  r2a,
+                  r2b
+                 }).
+
+-record(record3, {r3a = 8#42423 bor
+                      8#4234,
+                  r3b = 8#5432
+                      bor 2#1010101,
+                  r3c = 123 +
+                      234,
+                  r3d}).
+
+-record(record5,
+        { r5a = 1 :: integer()
+        , r5b = foobar :: atom()
+        }).
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/terms
+++ b/apps/sourcer/test/sourcer_indent_tests_data/terms
@@ -1,0 +1,174 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of terms contain builtin types
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+
+list(1) ->
+    [a,
+     b,
+     c
+    ];
+list(2) ->
+    [ a,
+      b, c
+    ];
+list(3) ->
+    [
+     a,
+     b, c
+    ];
+list(4) ->
+    [ a
+    , b
+    , c
+    ].
+
+tuple(1) ->
+    {a,
+     b,c
+    };
+tuple(2) ->
+    { a,
+      b,c
+    };
+tuple(3) ->
+    {
+     a,
+     b,c
+    };
+tuple(4) ->
+    { a
+    , b
+    ,c
+    }.
+
+binary(1) ->
+    <<1:8,
+      2:8
+    >>;
+binary(2) ->
+    <<
+      1:8,
+      2:8
+    >>;
+binary(3) ->
+    << 1:8,
+       2:8
+    >>;
+binary(4) ->
+    <<
+      1:8
+     ,2:8
+    >>;
+binary(5) ->
+    << 1:8
+     , 2:8
+    >>.
+
+record(1) ->
+    #record{a=1,
+            b=2
+           };
+record(2) ->
+    #record{ a=1,
+             b=2
+           };
+record(3) ->
+    #record{
+       a=1,
+       b=2
+      };
+record(4) ->
+    #record{
+       a=1
+      ,b=2
+      };
+record(Record) ->
+    Record#record{
+      a=1
+     ,b=2
+     }.
+
+map(1) ->
+    #{a=>1,
+      b=>2
+     };
+map(2) ->
+    #{ a=>1,
+       b=>2
+     };
+map(3) ->
+    #{
+      a=>1,
+      b=>2
+     };
+map(4) ->
+    #{
+      a => <<"a">>
+     ,b => 2
+     };
+map(MapVar) ->
+    MapVar = #{a :=<<"a">>
+              ,b:=1}.
+
+deep(Rec) ->
+    Rec#rec{ atom = 'atom',
+             map = #{ k1 => {v,
+                             1},
+                      k2 => [
+                             1,
+                             2,
+                             3
+                            ],
+                      {key,
+                       3}
+                      =>
+                          <<
+                            123:8,
+                            255:8
+                          >>
+                    }
+           }.
+
+%% Record indentation
+some_function_with_a_very_long_name() ->
+    #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+       field1=a,
+       field2=b},
+    case dummy_function_with_a_very_very_long_name(x) of
+        #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+           field1=a,
+           field2=b} ->
+            ok;
+        Var = #'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+                 field1=a,
+                 field2=b} ->
+            Var#'a-long-record-name-like-it-sometimes-is-with-asn.1-records'{
+              field1=a,
+              field2=b};
+        #xyz{
+           a=1,
+           b=2} ->
+            ok
+    end.
+
+some_function_name_xyz(xyzzy, #some_record{
+                                 field1=Field1,
+                                 field2=Field2}) ->
+    SomeVariable = f(#'Some-long-record-name'{
+                        field_a = 1,
+                        'inter-xyz-parameters' =
+                            #'Some-other-very-long-record-name'{
+                               field2 = Field1,
+                               field2 = Field2}}),
+    {ok, SomeVariable}.
+
+foo() ->
+    [#foo{
+        foo = foo}].

--- a/apps/sourcer/test/sourcer_indent_tests_data/try_catch
+++ b/apps/sourcer/test/sourcer_indent_tests_data/try_catch
@@ -1,0 +1,166 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% Try and catch indentation is hard
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+try_catch() ->
+    try
+        io:format(stdout, "Parsing file ~s, ",
+                  [St0#leex.xfile]),
+        {ok,Line3,REAs,Actions,St3} =
+            parse_rules(Xfile, Line2, Macs, St2)
+    catch
+        exit:{badarg,R} ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R);
+        error:R
+          when R =:= 42 ->			% when should be indented
+            foo(R);
+        error:R
+          when					% when should be indented
+              R =:= 42 ->			% but unsure about this (maybe 2 more)
+            foo(R);
+        error:R when
+              R =:= foo ->			% line should be 2 indented (works)
+            foo(R);
+        error:R ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R)
+    after
+        foo('after'),
+        file:close(Xfile)
+    end;
+try_catch() ->
+    try
+        foo(bar)
+    of
+        X when true andalso
+              kalle -> %% Differ Emacs align inconsistent
+            io:format(stdout, "Parsing file ~s, ",
+                      [St0#leex.xfile]),
+            {ok,Line3,REAs,Actions,St3} =
+                parse_rules(Xfile, Line2, Macs, St2);
+        X
+          when false andalso			% when should be 2 indented
+              bengt -> %% Differ Emacs align inconsistent
+            gurka();
+        X when
+              false andalso			% line should be 2 indented
+              not bengt ->
+            gurka();
+        X ->
+            io:format(stdout, "Parsing file ~s, ",
+                      [St0#leex.xfile]),
+            {ok,Line3,REAs,Actions,St3} =
+                parse_rules(Xfile, Line2, Macs, St2)
+    catch
+        exit:{badarg,R} ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R);
+        error:R ->
+            foo(R),
+            io:format(stdout,
+                      "ERROR reason ~p~n",
+                      R)
+    after
+        foo('after'),
+        file:close(Xfile),
+        bar(with_long_arg,
+            with_second_arg)
+    end;
+try_catch() ->
+    try foo()
+    after
+        foo(),
+        bar(with_long_arg,
+            with_second_arg)
+    end.
+
+indent_catch() ->
+    D = B +
+        float(43.1),
+
+    B = catch oskar(X),
+
+    A = catch (baz +
+               bax),   %% Differ Emacs align inconsistent
+    catch foo(),
+
+    C = catch B +
+        float(43.1),
+
+    case catch foo(X) of
+        A ->
+            B
+    end,
+
+    case
+        catch foo(X)
+    of
+        A ->
+            B
+    end,
+
+    case
+        foo(X)
+    of
+        A ->
+            catch B,
+            X
+    end,
+
+    try sune of
+        _ -> foo
+    catch _:_ -> baf
+    end,
+
+    Variable = try
+                   sune
+               of
+                   _ ->
+                       X = 5,
+                       (catch foo(X)),
+                       X + 10
+               catch _:_ -> baf
+               after cleanup()
+               end,
+
+    try
+        (catch sune)
+    of
+        _ ->
+            foo1(),
+            catch foo() %% Emacs bugs
+    catch _:_ ->
+            baf
+    end,
+
+    try
+        (catch exit())
+    catch
+        _ ->
+            catch baf()
+    end,
+    ok.
+
+%% this used to result in 2x the correct indentation within the function
+%% body, due to the function name being mistaken for a keyword
+catcher(N) ->
+    try generate_exception(N) of
+        Val -> {N, normal, Val}
+    catch
+        throw:X -> {N, caught, thrown, X};
+        exit:X -> {N, caught, exited, X};
+        error:X -> {N, caught, error, X}
+    end.

--- a/apps/sourcer/test/sourcer_indent_tests_data/type_specs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/type_specs
@@ -1,0 +1,109 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%% Tests how types and specs are indented (also that the editor can parse them)
+%% May need improvements
+
+
+-type ann() :: Var :: integer().
+-type ann2() :: 'return'
+              | 'return_white_spaces'
+              | 'return_comments'
+              | 'text' | ann().
+-type paren() ::
+        (ann2()).
+
+-type t6() ::
+        1 | 2 | 3 |
+        'foo'
+      | 'bar'.
+
+-type t8() :: {any(),none(),pid(),port(),
+               reference(),float()}.
+
+-type t14() :: [erl_scan:foo() |
+                %% Should be highlighted
+                term() |
+                boolean() |
+                byte() |
+                char() |
+                non_neg_integer() | nonempty_list() |
+                pos_integer() |
+                neg_integer() |
+                number() |
+                list() |
+                nonempty_improper_list() | nonempty_maybe_improper_list() |
+                maybe_improper_list() | string() | iolist() | byte() |
+                module() |
+                mfa()   |
+                node()  |
+                timeout() |
+                no_return() |
+                %% Should not be highlighted
+                nonempty_() | nonlist() |
+                erl_scan:bar(34, 92) | t13() | m:f(integer() | <<_:_*16>>)].
+
+-type t15() :: {binary(),<<>>,<<_:34>>,<<_:_*42>>,
+                <<_:3,_:_*14>>,<<>>} | [<<>>|<<_:34>>|<<_:16>>|
+                                        <<_:3,_:_*1472>>|<<_:19,_:_*14>>| <<_:34>>|
+                                        <<_:34>>|<<_:34>>|<<_:34>>].
+
+-type t18() ::
+        fun(() -> t17() | t16()).
+-type t19() ::
+        fun((t18()) -> t16()) |
+        fun((nonempty_maybe_improper_list('integer', any())|
+             1|2|3|a|b|<<_:3,_:_*14>>|integer())
+            ->
+                nonempty_maybe_improper_list('integer', any())| % Emacs differ
+                1|2|3|a|b|<<_:3,_:_*14>>|integer()). % Emacs differ
+-type t20() :: [t19(), ...].
+-type t25() :: #rec3{f123 :: [t24() |
+                              1|2|3|4|a|b|c|d|
+                              nonempty_maybe_improper_list(integer, any())]}.
+-type t26() :: #rec4{ a :: integer()
+                    , b :: any()
+                    }.
+
+%% Spec
+
+-spec t1(FooBar :: t99()) -> t99();
+        (t2()) -> t2();
+        (t4()) -> t4() when is_subtype(t4(), t24);
+        (t23()) -> t23() when is_subtype(t23(), atom()),
+                              is_subtype(t23(), t14());
+        (t24()) -> t24() when is_subtype(t24(), atom()),
+                              is_subtype(t24(), t14()),
+                              is_subtype(t24(), t4()).
+
+-spec over(I :: integer()) -> R1 :: foo:typen();
+          (A :: atom()) -> R2 :: foo:atomen();
+          (T :: tuple()) -> R3 :: bar:typen().
+
+-spec mod:t2() -> any().
+
+-spec handle_cast(Cast :: {'exchange', node(), [[name(),...]]}
+                | {'del_member', name(), pid()}, % Emacs differ
+                  #state{}) -> {'noreply', #state{}}.
+
+-spec handle_cast(Cast ::
+                    {'exchange', node(), [[name(),...]]}
+                | {'del_member', name(), pid()}, % Emacs differ
+                  #state{}) ->
+          {'noreply', #state{}}.
+
+-spec all(fun((T) -> boolean()), List :: [T]) ->
+          boolean() when is_subtype(T, term()). % (*) % Emacs differ
+
+-spec get_closest_pid(term()) ->
+          Return :: pid()
+        | {'error', {'no_process', term()}} % Emacs differ
+        | {'no_such_group', term()}}.       % Emacs differ
+
+-spec add( X :: integer()
+         , Y :: integer()
+         ) -> integer().
+
+-opaque attributes_data() ::
+          [{'column', column()} | {'line', info_line()} |
+           {'text', string()}] |  {line(),column()}.


### PR DESCRIPTION
Large rewrite of the old module.

Added testcases and a  `erlang_ls -i FILE` option to indent erlang src from command line.
Which could be useful.

Have temporary removed `sourcer_indent:line(...)` functionality which needs to be added
to be useful from lsp_server. 
But that can be added later and I don't have more time to work on this right now.