### PR TITLE
More fixes and tests

### DIFF
--- a/apps/sourcer/test/sourcer_indent_tests.erl
+++ b/apps/sourcer/test/sourcer_indent_tests.erl
@@ -1,7 +1,7 @@
 %%
 %%
 -module(sourcer_indent_tests).
-
+-export([sourcer/1]).
 -include_lib("eunit/include/eunit.hrl").
 
 indent_test_() ->
@@ -10,7 +10,7 @@ indent_test_() ->
     io:format("Dir: ~s~nFs: ~p~n", [Dir, OrigFs]),
     Fs = [{File, unindent(File)} || File <- OrigFs,
                                     filename:extension(File) =:= ""],
-    Indent = fun sourcerer/1,
+    Indent = fun sourcer/1,
     [Indent(File) || {_, File} <- Fs],
     Res = [diff(Orig, File) || {Orig, File} <- Fs],
     {setup, 
@@ -40,7 +40,7 @@ diff(Orig, File) ->
             {fail, File}
     end.
 
-sourcerer(File) ->
+sourcer(File) ->
     io:format("* Indenting: ~s *~n",[File]),
     {ok, Bin} = file:read_file(File),
     Src = unicode:characters_to_list(Bin),

--- a/apps/sourcer/test/sourcer_indent_tests_data/errors
+++ b/apps/sourcer/test/sourcer_indent_tests_data/errors
@@ -1,0 +1,10 @@
+%% -*- erlang -*-
+%%
+%% Test different parse or syntax errors.
+%%
+
+%% This one caused an eternal loop in the parser
+forever(1) ->
+    foo
+end.
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/icr
+++ b/apps/sourcer/test/sourcer_indent_tests_data/icr
@@ -60,10 +60,10 @@ indent_case(1, Z) ->
             foo(X);
         {Z,_,_}
           when   Z < 10 orelse
-              Z =:= foo ->			% emacs differ see below
+                 Z =:= foo ->
             X = 43 div 4,
             Bool = Z < 5 orelse                 % Emacs Binary op args align differently after when
-                Z =:= foo,                      % and elsewhere ???
+                   Z =:= foo,
             foo(X);
         {Z,_,_}
           when					% when should be indented

--- a/apps/sourcer/test/sourcer_indent_tests_data/macros
+++ b/apps/sourcer/test/sourcer_indent_tests_data/macros
@@ -33,3 +33,28 @@
 -else().
 -define(LOG, ok).
 -endif().
+
+-define(PARSE_XML_DECL(Bytes, State),
+        parse_xml_decl(Bytes, #xmerl_sax_parser_state{encoding=Enc} = State)
+          when is_binary(Bytes) ->
+            case unicode:characters_to_list(Bytes, Enc) of
+                {incomplete, _, _} ->
+                    cf(Bytes, State, fun parse_xml_decl/2);
+                {error, _Encoded, _Rest} ->
+                    ?fatal_error(State,  "Bad character");
+                _ ->
+                    parse_prolog(Bytes, State)
+            end;
+        parse_xml_decl(Bytes, State) ->
+            parse_prolog(Bytes, State)).
+
+
+-define(fatal(Reason, S),
+        if
+            S#record.quiet ->
+                ok;
+            true ->
+                error_logger:error_msg("~p- fatal: ~p~n", [?LINE, Reason]),
+                ok
+        end,
+        fatal(Reason, S)).

--- a/apps/sourcer/test/sourcer_indent_tests_data/macros
+++ b/apps/sourcer/test/sourcer_indent_tests_data/macros
@@ -3,6 +3,10 @@
 
 %%% Macros should be indented as code
 
+-export([
+        ]
+       ).
+
 -define(M0, ok).
 
 -define(M1,

--- a/apps/sourcer/test/sourcer_indent_tests_data/records
+++ b/apps/sourcer/test/sourcer_indent_tests_data/records
@@ -21,11 +21,11 @@
                  }).
 
 -record(record3, {r3a = 8#42423 bor
-                      8#4234,
+                        8#4234,  %% differ emacs
                   r3b = 8#5432
-                      bor 2#1010101,
+                        bor 2#1010101, %% differ emacs
                   r3c = 123 +
-                      234,
+                        234, %% differ emacs
                   r3d}).
 
 -record(record5,

--- a/apps/sourcer/test/sourcer_indent_tests_data/records
+++ b/apps/sourcer/test/sourcer_indent_tests_data/records
@@ -33,3 +33,8 @@
         , r5b = foobar :: atom()
         }).
 
+
+record_usage(A) ->
+    %% Test parser
+    A = bnot (id())#record_usage.r5a,
+    {ok, A}.

--- a/apps/sourcer/test/sourcer_indent_tests_data/terms
+++ b/apps/sourcer/test/sourcer_indent_tests_data/terms
@@ -49,7 +49,7 @@ tuple(4) ->
     }.
 
 binary(1) ->
-    <<1:8,
+    <<1:8/unsigned-native,
       2:8
     >>;
 binary(2) ->
@@ -69,7 +69,10 @@ binary(4) ->
 binary(5) ->
     << 1:8
      , 2:8
-    >>.
+     , ?macro1():?macro2()
+    >>;
+binary(6) ->
+    <<0.0:32/float>>;
 
 record(1) ->
     #record{a=1,
@@ -172,3 +175,16 @@ some_function_name_xyz(xyzzy, #some_record{
 foo() ->
     [#foo{
         foo = foo}].
+
+list_string() ->
+    ListString = "sune L"
+                 "kalle L"
+                 "oskar L",
+    {ok, ListString}.
+
+binary_string() ->
+    BinString = <<"sune B"
+                  "kalle B"
+                  "oskar B"/binary>>,
+    {ok, BinString}.
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/try_catch
+++ b/apps/sourcer/test/sourcer_indent_tests_data/try_catch
@@ -44,14 +44,14 @@ try_catch() ->
         foo(bar)
     of
         X when true andalso
-              kalle -> %% Differ Emacs align inconsistent
+               kalle ->
             io:format(stdout, "Parsing file ~s, ",
                       [St0#leex.xfile]),
             {ok,Line3,REAs,Actions,St3} =
                 parse_rules(Xfile, Line2, Macs, St2);
         X
-          when false andalso			% when should be 2 indented
-              bengt -> %% Differ Emacs align inconsistent
+          when false andalso
+               bengt ->
             gurka();
         X when
               false andalso			% line should be 2 indented
@@ -94,7 +94,7 @@ indent_catch() ->
     B = catch oskar(X),
 
     A = catch (baz +
-               bax),   %% Differ Emacs align inconsistent
+               bax),
     catch foo(),
 
     C = catch B +

--- a/apps/sourcer/test/sourcer_indent_tests_data/type_specs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/type_specs
@@ -83,12 +83,12 @@
 -spec mod:t2() -> any().
 
 -spec handle_cast(Cast :: {'exchange', node(), [[name(),...]]}
-                | {'del_member', name(), pid()}, % Emacs differ
+                        | {'del_member', name(), pid()},
                   #state{}) -> {'noreply', #state{}}.
 
 -spec handle_cast(Cast ::
                     {'exchange', node(), [[name(),...]]}
-                | {'del_member', name(), pid()}, % Emacs differ
+                  | {'del_member', name(), pid()},
                   #state{}) ->
           {'noreply', #state{}}.
 
@@ -97,8 +97,8 @@
 
 -spec get_closest_pid(term()) ->
           Return :: pid()
-        | {'error', {'no_process', term()}} % Emacs differ
-        | {'no_such_group', term()}}.       % Emacs differ
+                  | {'error', {'no_process', term()}}
+                  | {'no_such_group', term()}}.
 
 -spec add( X :: integer()
          , Y :: integer()
@@ -107,3 +107,33 @@
 -opaque attributes_data() ::
           [{'column', column()} | {'line', info_line()} |
            {'text', string()}] |  {line(),column()}.
+
+
+-callback handle_call(Request :: term(),
+                      From :: {pid(),
+                               Tag :: term()},
+                      State :: term()) ->
+              {reply, Reply :: term(), NewState :: term()} |
+              {reply, Reply :: term(), NewState :: term(), timeout() | hibernate} |
+              {noreply, NewState :: term()} |
+              {noreply, NewState :: term(), timeout() | hibernate} |
+              {stop, Reason :: term(), Reply :: term(), NewState :: term()} |
+              {stop, Reason :: term(), NewState :: term()}.
+
+-spec load(AppDescr, Distributed) ->
+          'ok' | {'error', Reason} when
+      AppDescr :: Application | (AppSpec :: application_spec()),
+      Application :: atom(),
+      Distributed :: {Application,Nodes}
+                   | {Application,Time,Nodes}
+                   | 'default',
+      Nodes :: [node() | tuple_of(node())],
+      Time :: pos_integer(),
+      Reason :: term().
+
+-spec sparse_push_tuple_pairs(non_neg_integer(), array_indx(),
+                              _, _, indx_pairs(Type)) -> indx_pairs(Type).
+
+-type f() :: {module(), atom(), list()}
+           | nonempty_maybe_improper_list(fun(), list())
+           | fun().

--- a/rebar.config
+++ b/rebar.config
@@ -47,3 +47,5 @@
 
 {escript_main_app, erlang_ls}.
 {escript_comment, "%% v0.2.0\n"}.
+
+{provider_hooks, [{post, [{compile, escriptize}]}]}.


### PR DESCRIPTION
Want to make a PR before we change the scanner and I'll get a large rebase.

Still does not contain a sourcer_indent:line(..) we have to think about that.

Also a couple of large optimizations can still be done; 
-  Only rescan one line 
-  Do not (re)parse all clauses only the last.
 
I need/want the scanner change first before writing the optimizations, so I know the line numbering is correct for all cases.

@fenollp Is this something your are interested in and can test? 
An erlang file indenter, (which I in long run want to be the standard instead emacs variant)
 _build/default/bin/erlang_ls -v -i *.erl

This has more promise than the emacs variant which is regexp based and can not parse the code
as erlang_ls can do (when all bugs have been squashed).

We know that multiline strings are broken, we need to fix the scanner for that.