### PR TITLE
Indentation improvements and api changes

### DIFF
--- a/apps/erlang_ls/src/erlang_ls.erl
+++ b/apps/erlang_ls/src/erlang_ls.erl
@@ -69,7 +69,7 @@ indent([File|Files], Verbose) ->
             {ok, BinSrc} ->
                 Enc = encoding(BinSrc),
                 Src = unicode:characters_to_list(BinSrc, Enc),
-                {ST,Indented} = timer:tc(fun() -> sourcer_indent:lines(Src) end),
+                {ST,Indented} = timer:tc(fun() -> sourcer_indent:all(Src) end),
                 ok = file:write_file(File, unicode:characters_to_binary(Indented, utf8, Enc)),
                 Verbose > 0 andalso io:format("Indent: ~.6wms ~s~n", [ST div 1000, File]),
                 indent(Files, Verbose);

--- a/apps/sourcer/src/sourcer.erl
+++ b/apps/sourcer/src/sourcer.erl
@@ -237,7 +237,9 @@
 'textDocument/formatting'(State, #{textDocument:=#{uri:=URI}, options:=Options}, Reporter) ->
     #{tabSize:=TabSize, insertSpaces:=InsertSpaces} = Options,
     Text = sourcer_documents:get_text(State#state.open_files, URI),
-    NewText = sourcer_indent:lines(unicode:characters_to_list(Text)),
+    NewText = sourcer_indent:all(unicode:characters_to_list(Text),
+                                 [{tab_len,TabSize},
+                                  {use_tabs,not InsertSpaces}]),
     Res = [#{range=>range({{0,1},{9991, 1}}),
             newText=>unicode:characters_to_binary(NewText)}],
     Reporter({value, Res}).

--- a/apps/sourcer/src/sourcer_scan.erl
+++ b/apps/sourcer/src/sourcer_scan.erl
@@ -111,13 +111,11 @@ tokens_1({Cont, Orig}, Str, {_,_}=Start, Last) ->
     case erl_scan:tokens(Cont, Str, Start, [return_comments, text]) of
         {done, {ok, Tokens0, {Next,_} = EndLoc}, Rest} when Next < Last ->
             Tokens = convert_tokens(Tokens0),
-            {_, LastLoc, _, _} = lists:last(Tokens),
-            [{Tokens, Start, LastLoc} |
+            [{Tokens, Start, EndLoc} |
              tokens_1({[],""}, Rest, EndLoc, Last)];
-        {done, {ok, Tokens0, _EndLoc}, _Rest} ->
+        {done, {ok, Tokens0, EndLoc}, _Rest} ->
             Tokens = convert_tokens(Tokens0),
-            {_, LastLoc, _, _} = lists:last(Tokens),
-            [{Tokens, Start, LastLoc}];
+            [{Tokens, Start, EndLoc}];
         {done, {eof, _EndLoc}, _Rest} ->
             [];
         {done, {error, {ErrorLoc, _, _}=_Info, EndLoc}, Rest} ->

--- a/apps/sourcer/src/sourcer_scan.erl
+++ b/apps/sourcer/src/sourcer_scan.erl
@@ -3,7 +3,7 @@
 -define(DEBUG, true).
 -include("debug.hrl").
 
--export([line_info/1,
+-export([line_info/1, split_lines/1,
          string/1, string/2, string/3,
          tokens/1, tokens/3,
          filter_ws_tokens/1,
@@ -54,6 +54,18 @@ get_indent(String) ->
          (C >= $\000 andalso C =< $\s orelse C >= $\200 andalso C =< $\240)).
 is_white_space(C) -> ?WHITE_SPACE(C).
 
+-spec split_lines(string()) -> [string()].
+split_lines(Str) ->
+    split_lines(Str, []).
+
+split_lines("\n" ++ Rest, Line) ->
+    [lists:reverse(Line, "\n")|split_lines(Rest,[])];
+split_lines([C|Rest], Line) ->
+    split_lines(Rest, [C|Line]);
+split_lines([], Line) ->
+    [lists:reverse(Line)].
+
+
 -spec string(string()) -> {ok, [token()], any()} | {error, any()}.
 string(String) ->
     string(String, {0, 1}).
@@ -89,30 +101,55 @@ string2(String, {L, C}, Opts) ->
     end.
 
 tokens(Str) ->
-    tokens_1([], Str, {0, 1}, all).
+    tokens_1({[],""}, Str, {0, 1}, all).
 
 tokens(Str, Loc, Last) ->
-    tokens_1([], Str, Loc, Last).
+    tokens_1({[],""}, Str, Loc, Last).
 
 %% Scans Str after tokens until line
-tokens_1(Cont, Str, {_,_}=Start, Last) ->
+tokens_1({Cont, Orig}, Str, {_,_}=Start, Last) ->
     case erl_scan:tokens(Cont, Str, Start, [return_comments, text]) of
         {done, {ok, Tokens0, {Next,_} = EndLoc}, Rest} when Next < Last ->
             Tokens = convert_tokens(Tokens0),
             {_, LastLoc, _, _} = lists:last(Tokens),
-            [{Tokens, Start, LastLoc} | tokens_1([], Rest, EndLoc, Last)];
+            [{Tokens, Start, LastLoc} |
+             tokens_1({[],""}, Rest, EndLoc, Last)];
         {done, {ok, Tokens0, _EndLoc}, _Rest} ->
             Tokens = convert_tokens(Tokens0),
             {_, LastLoc, _, _} = lists:last(Tokens),
             [{Tokens, Start, LastLoc}];
         {done, {eof, _EndLoc}, _Rest} ->
             [];
-        {done, {error, Info, EndLoc}, Rest} ->
-            %% FIXME (investigate scanner errors)
-            io:format("Scanner Error: ~p~n",[Info]),
-            tokens_1([], Rest, EndLoc, Last);
+        {done, {error, {ErrorLoc, _, _}=_Info, EndLoc}, Rest} ->
+            Until = case Orig of
+                        "" -> until_error(Str, Start, ErrorLoc);
+                        _  -> until_error(Orig, Start, ErrorLoc)
+                    end,
+            [{BefTokens,SLoc,_}] = tokens_1({[],""}, Until, Start, Last),
+            ErrToken = {scan_error, ErrorLoc, "", undefined},
+            case tokens_1({[],""}, Rest, EndLoc, Last) of
+                [] ->
+                    [{BefTokens++[ErrToken], SLoc, EndLoc}];
+                [{AfterTokens,_, ELoc}|RestForms] ->
+                    [{BefTokens++[ErrToken|AfterTokens], SLoc, ELoc}|RestForms]
+            end;
         {more, More} ->
-            tokens_1(More, eof, Start, Last)
+            tokens_1({More, Str}, eof, Start, Last)
+    end.
+
+until_error(Str, {SL,SC}, {EL,EC}) ->
+    until_error(Str, SL, SC, EL, EC).
+
+until_error([Char|Str], SL, SC, EL, EC) ->
+    if SL < EL ->
+            case Char =:= $\n of
+                true -> [$\n|until_error(Str, SL+1, 1, EL, EC)];
+                false -> [Char|until_error(Str,SL,SC,EL,EC)]
+            end;
+       SC < EC ->
+            [Char|until_error(Str, SL, SC+1, EL, EC)];
+       true ->
+            []
     end.
 
 filter_tokens_by_kinds(Tokens, Kinds) ->

--- a/apps/sourcer/test/sourcer_indent_tests_data/comments
+++ b/apps/sourcer/test/sourcer_indent_tests_data/comments
@@ -22,4 +22,4 @@ func() ->
             Other
     end,
     ok.
-
+                                                % after funktion

--- a/apps/sourcer/test/sourcer_indent_tests_data/errors
+++ b/apps/sourcer/test/sourcer_indent_tests_data/errors
@@ -8,3 +8,19 @@ forever(1) ->
     foo
 end.
 
+
+%% Check that we can handle scanner errors in some way
+
+scanner_errors() ->
+    Float = 6.28e1,
+    HalfFinishedFloat = 2.3e,
+ok.
+
+%% This needs to be last: uncompleted string
+
+uncomplete() ->
+    foo(),
+    UntilEof = "1
+2
+3
+ok.

--- a/apps/sourcer/test/sourcer_indent_tests_data/exprs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/exprs
@@ -28,3 +28,11 @@ bin_op({{Y,Mo,D},{H,Mi,S}}) ->
           two_digits(S)  ++ " ").
 
 
+double_match() ->
+    LongExpr = A =
+        foo,
+    VarA =:= VarB orelse
+        VarC =:= VarD orelse
+        VarE =:= VarD.
+
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/exprs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/exprs
@@ -1,0 +1,30 @@
+%% -*- Mode: erlang; indent-tabs-mode: nil -*-
+%% Copyright Ericsson AB 2017. All Rights Reserved.
+
+%%% indentation of exprs
+
+%%% Not everything in these test are set in stone
+%%% better indentation rules can be added but by having
+%%% these tests we can see what changes in new implementations
+%%% and notice when doing unintentional changes
+
+
+
+f1() ->
+    Var = [ a,
+            b
+          | c],
+    [ a1,
+      some_func(b)
+    | Var].
+
+bin_op({{Y,Mo,D},{H,Mi,S}}) ->
+    erlang:display_string(
+      integer_to_list(Y) ++ "-" ++
+          two_digits(Mo) ++ "-" ++
+          two_digits(D)  ++ " " ++
+          two_digits(H)  ++ ":" ++
+          two_digits(Mi) ++ ":" ++
+          two_digits(S)  ++ " ").
+
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/funcs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/funcs
@@ -79,6 +79,12 @@ when4(W1,W2,W3)
       W2 > W3 ->
     ok.
 
+when5(W1,W2,W3)
+  when
+      W1 > W2 orelse
+      W2 > W3 ->
+    ok.
+
 match1({[H|T],
         Other},
        M1A2) ->

--- a/apps/sourcer/test/sourcer_indent_tests_data/funcs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/funcs
@@ -54,6 +54,8 @@ a_function_with_a_very_very_long_name() ->
              field2=1
             },
     A00.
+directly_after() ->
+    ok.
 
 when1(W1, W2)
   when is_number(W1),

--- a/apps/sourcer/test/sourcer_indent_tests_data/funcs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/funcs
@@ -180,3 +180,8 @@ funs(4) ->
                     end, [], Z),
     A = <<X/binary, 0:8>>,
     A.
+
+function() ->
+    call_another
+      (X,
+       Y).

--- a/apps/sourcer/test/sourcer_indent_tests_data/highlight
+++ b/apps/sourcer/test/sourcer_indent_tests_data/highlight
@@ -73,6 +73,6 @@ highlighting(X)			  % Function definitions should be highlighted
     234234,
     234.43,
 
-    [list, are, not, higlighted],
+    [list, are, 'not', higlighted],
     {nor, is, tuple},
     ok.

--- a/apps/sourcer/test/sourcer_indent_tests_data/icr
+++ b/apps/sourcer/test/sourcer_indent_tests_data/icr
@@ -141,7 +141,8 @@ indent_receive(2) ->
         Z ->
             X = 43 div 4,
             foo(X)
-    after infinity ->
+    after
+        infinity ->
             foo(X),
             asd(X),
             5*43
@@ -155,13 +156,3 @@ indent_receive() ->
                        5*43
                end,
     ok.
-
-%% Not icr but binary operation outside of predicate lists
-display_date({{Y,Mo,D},{H,Mi,S}}) ->
-    erlang:display_string(
-      integer_to_list(Y) ++ "-" ++
-          two_digits(Mo) ++ "-" ++
-          two_digits(D)  ++ " " ++
-          two_digits(H)  ++ ":" ++
-          two_digits(Mi) ++ ":" ++
-          two_digits(S)  ++ " ").

--- a/apps/sourcer/test/sourcer_indent_tests_data/icr
+++ b/apps/sourcer/test/sourcer_indent_tests_data/icr
@@ -148,10 +148,20 @@ indent_receive(2) ->
     end,
     ok;
 indent_receive() ->
-    receive
-    after 10 ->
-            foo(X),
-            asd(X),
-            5*43
-    end,
+    MyResult = receive
+               after 10 ->
+                       foo(X),
+                       asd(X),
+                       5*43
+               end,
     ok.
+
+%% Not icr but binary operation outside of predicate lists
+display_date({{Y,Mo,D},{H,Mi,S}}) ->
+    erlang:display_string(
+      integer_to_list(Y) ++ "-" ++
+          two_digits(Mo) ++ "-" ++
+          two_digits(D)  ++ " " ++
+          two_digits(H)  ++ ":" ++
+          two_digits(Mi) ++ ":" ++
+          two_digits(S)  ++ " ").

--- a/apps/sourcer/test/sourcer_indent_tests_data/records
+++ b/apps/sourcer/test/sourcer_indent_tests_data/records
@@ -37,4 +37,17 @@
 record_usage(A) ->
     %% Test parser
     A = bnot (id())#record_usage.r5a,
-    {ok, A}.
+    Bool = Parms#?HASH_PARMS.bchunk_format_version =:=
+           ?BCHUNK_FORMAT_VERSION,
+    {ok, A, Bool}.
+
+record_usage(Argument) ->
+    B0 = Argument#record_usage
+           {field1 =
+                foo},
+    B0 = Argument#record_usage{
+           field1 =
+               foo},
+
+    {ok, B}.
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/terms
+++ b/apps/sourcer/test/sourcer_indent_tests_data/terms
@@ -188,3 +188,20 @@ binary_string() ->
                   "oskar B"/binary>>,
     {ok, BinString}.
 
+a_string_with_nl() ->
+    Str = "row1\nrow2\nrow3\n",
+    ok.
+
+ml_string() ->
+    ListString = "row 1L
+row 2L
+row 3L",
+    {ok, ListString}.
+
+bin_ml_string() ->
+    ListString = <<"row 1B
+row 2B
+row 3B">>,
+    {ok, ListString}.
+
+

--- a/apps/sourcer/test/sourcer_indent_tests_data/try_catch
+++ b/apps/sourcer/test/sourcer_indent_tests_data/try_catch
@@ -94,7 +94,7 @@ indent_catch() ->
     B = catch oskar(X),
 
     A = catch (baz +
-               bax),
+                   bax),
     catch foo(),
 
     C = catch B +
@@ -159,8 +159,7 @@ indent_catch() ->
 catcher(N) ->
     try generate_exception(N) of
         Val -> {N, normal, Val}
-    catch
-        throw:X -> {N, caught, thrown, X};
-        exit:X -> {N, caught, exited, X};
-        error:X -> {N, caught, error, X}
+    catch throw:X -> {N, caught, thrown, X};
+          exit:X -> {N, caught, exited, X};
+          error:X -> {N, caught, error, X}
     end.

--- a/apps/sourcer/test/sourcer_indent_tests_data/try_catch
+++ b/apps/sourcer/test/sourcer_indent_tests_data/try_catch
@@ -94,11 +94,11 @@ indent_catch() ->
     B = catch oskar(X),
 
     A = catch (baz +
-                   bax),
+               bax),
     catch foo(),
 
     C = catch B +
-        float(43.1),
+              float(43.1),
 
     case catch foo(X) of
         A ->
@@ -162,4 +162,11 @@ catcher(N) ->
     catch throw:X -> {N, caught, thrown, X};
           exit:X -> {N, caught, exited, X};
           error:X -> {N, caught, error, X}
+    end.
+
+unary_ops() ->
+    case catch
+           func() of
+        asd ->
+            ok
     end.

--- a/apps/sourcer/test/sourcer_indent_tests_data/type_specs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/type_specs
@@ -100,7 +100,7 @@
 -spec get_closest_pid(term()) ->
           Return :: pid()
                   | {'error', {'no_process', term()}}
-                  | {'no_such_group', term()}}.
+                  | {'no_such_group', term()}.
 
 -spec add( X :: integer()
          , Y :: integer()

--- a/apps/sourcer/test/sourcer_indent_tests_data/type_specs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/type_specs
@@ -78,9 +78,12 @@
                               is_subtype(t24(), t14()),
                               is_subtype(t24(), t4()).
 
--spec over(I :: integer()) -> R1 :: foo:typen();
-          (A :: atom()) -> R2 :: foo:atomen();
-          (T :: tuple()) -> R3 :: bar:typen().
+-spec over_spec(I :: integer()) ->
+          R1 :: foo:typen();
+               (A :: atom()) ->
+          R2 :: foo:atomen();
+               (T :: tuple()) ->
+          R3 :: bar:typen().
 
 -spec mod:t2() -> any().
 
@@ -94,7 +97,8 @@
                   #state{}) ->
           {'noreply', #state{}}.
 
--spec all(fun((T) -> boolean()), List :: [T]) ->
+-spec all(
+        fun((T) -> boolean()), List :: [T]) ->
           boolean() when is_subtype(T, term()). % (*) % Emacs differ
 
 -spec get_closest_pid(term()) ->
@@ -140,12 +144,25 @@
            | nonempty_maybe_improper_list(fun(), list())
            | fun().
 
--spec logfile(Request :: {open, Filename}) -> ok | {error, OpenReason} when
+-spec logfile(Request :: {open, Filename}) ->
+          ok | {error, OpenReason} when
       Filename ::file:name(),
       OpenReason :: allready_have_logfile | open_error();
-             (Request :: close) -> ok | {error, CloseReason} when
+             (Request :: close) ->
+          ok | {error, CloseReason}
+      when
       CloseReason :: module_not_found
-           ; (Request :: filename) -> Filename | {error, FilenameReason} when
+           ; (Request :: filename) ->
+          Filename | {error, FilenameReason} when
       Filename :: file:name(),
       FilenameReason :: no_log_file.
 
+%% Old style
+
+-spec(exprs(Expressions, Bindings, LocalFunctionHandler) ->
+          {value, Value, NewBindings} when
+      Expressions :: expressions(),
+      Bindings :: binding_struct(),
+      LocalFunctionHandler :: local_function_handler(),
+      Value :: value(),
+      NewBindings :: binding_struct()).

--- a/apps/sourcer/test/sourcer_indent_tests_data/type_specs
+++ b/apps/sourcer/test/sourcer_indent_tests_data/type_specs
@@ -49,14 +49,16 @@
                                         <<_:34>>|<<_:34>>|<<_:34>>].
 
 -type t18() ::
-        fun(() -> t17() | t16()).
+        fun(() ->
+            t17() | t16()
+           ).
 -type t19() ::
         fun((t18()) -> t16()) |
         fun((nonempty_maybe_improper_list('integer', any())|
              1|2|3|a|b|<<_:3,_:_*14>>|integer())
             ->
-                nonempty_maybe_improper_list('integer', any())| % Emacs differ
-                1|2|3|a|b|<<_:3,_:_*14>>|integer()). % Emacs differ
+            nonempty_maybe_improper_list('integer', any())| % Emacs differ
+            1|2|3|a|b|<<_:3,_:_*14>>|integer()). % Emacs differ
 -type t20() :: [t19(), ...].
 -type t25() :: #rec3{f123 :: [t24() |
                               1|2|3|4|a|b|c|d|
@@ -137,3 +139,13 @@
 -type f() :: {module(), atom(), list()}
            | nonempty_maybe_improper_list(fun(), list())
            | fun().
+
+-spec logfile(Request :: {open, Filename}) -> ok | {error, OpenReason} when
+      Filename ::file:name(),
+      OpenReason :: allready_have_logfile | open_error();
+             (Request :: close) -> ok | {error, CloseReason} when
+      CloseReason :: module_not_found
+           ; (Request :: filename) -> Filename | {error, FilenameReason} when
+      Filename :: file:name(),
+      FilenameReason :: no_log_file.
+


### PR DESCRIPTION
Change the api to:

```erlang
-spec all(InputSrc::string(),
            Opts::[{atom(), integer()|boolean()}]) ->
          OutSrc::string().
-spec lines(From::non_neg_integer(),
            To::non_neg_integer(),
            InputSrc::string(),
            Opts::[{atom(), integer()|boolean()}]) ->
          Changed::[{LineNr::integer(), OrigLine::string(), IndentedLine::string()}].
-spec line(LineNr::non_neg_integer(),
           InputSrc::string(),
           Opts::[{atom(), integer()|boolean()}]) ->
          Line :: string().
```

And lots of bugfixes some optimizations after testing more against OTP code.

I don't know what you want from returned from `line/[2,3]` but the return value is easily changed.
the `line` api is not that much tested and will need more tests and probably bug fixes.
