### PR TITLE
Fixes for stdio mode (tested with lsp-mode for emacs)

### DIFF
--- a/apps/lsp_server/src/jsonrpc.erl
+++ b/apps/lsp_server/src/jsonrpc.erl
@@ -75,7 +75,8 @@ start_stdio(Server, Client, Options) ->
 
 stdio_accept(Self) ->
 	spawn(fun() -> 
-			stdio_loop(Self) 
+			InPort = stdio_init(),
+			stdio_loop(Self, InPort)
 		end).
 
 loop(Handler, Server, Client, Options, Buf, Pending, Results) ->
@@ -122,17 +123,33 @@ loop(Handler, Server, Client, Options, Buf, Pending, Results) ->
 			loop(Handler, Server, Client, Options, Buf, Pending, Results)
 	end.
 
-stdio_loop(Peer) ->
-	case io:get_line('') of
-		eof ->
-			?TRACE("jsonrpc eof~n", []),
-			ok;
-		{error, Error} ->
-			?TRACE("jsonrpc error: ~p~n", [Error]),
-			ok;
-		Data ->
-			Peer ! {data, Data},
-			stdio_loop(Peer)
+stdio_init() ->
+    %% Open a port to read from standard input instead of using one of
+    %% the io built-ins.
+    %%
+    %% io:get_line/1 will not work since (at least) lsp-mode for emacs
+    %% will send an LSP packet with a trailing "}" for the jsonrpc but
+    %% no newline.
+    %%
+    %% io:get_chars/2 would work, but forces us to read 1 character at
+    %% a time which is unnecessarily inefficient.
+    %%
+    %% Open a port towards fd 0 instead.  Requires the erlang node to
+    %% be started with parameter "-noinput".
+    open_port({fd, 0, 1}, [in, binary, stream]).
+
+stdio_loop(Peer, InPort) ->
+        receive
+            {InPort, {data, Data}} ->
+                ?TRACE("jsonrpc data: ~p~n", [Data]),
+                Peer ! {data, Data},
+                stdio_loop(Peer, InPort);
+            {'EXIT', InPort, normal} ->
+                ?TRACE("jsonrpc in port closed~n", []),
+                ok;
+            {'EXIT', InPort, Reason} ->
+                ?TRACE("jsonrpc in port closed with reason: ~p~n", [Reason]),
+                ok
 	end.
 
 try_decode(Buf) ->

--- a/apps/lsp_server/src/jsonrpc.erl
+++ b/apps/lsp_server/src/jsonrpc.erl
@@ -12,8 +12,8 @@
 		send_reply/2
 	]).
 
--define(TRACE, true).
--define(DEBUG, true).
+%%-define(TRACE, true).
+%%-define(DEBUG, true).
 
 -ifdef(TRACE).
 -define(TRACE(F, A), io:format(F, A)).

--- a/apps/lsp_server/src/lsp_server.erl
+++ b/apps/lsp_server/src/lsp_server.erl
@@ -32,7 +32,7 @@ start_link(Mod) ->
 				%% (unless it's a worskpace operation)
 			   }).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 
 -ifdef(DEBUG).
 -define(DEBUG(F, A), io:format(F, A)).

--- a/apps/sourcer/src/sourcer.erl
+++ b/apps/sourcer/src/sourcer.erl
@@ -36,7 +36,7 @@
         %'textDocument/rename'/3,
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_analyse.erl
+++ b/apps/sourcer/src/sourcer_analyse.erl
@@ -8,7 +8,7 @@
 
 -include("sourcer_model.hrl").
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 merge([])  ->

--- a/apps/sourcer/src/sourcer_db.erl
+++ b/apps/sourcer/src/sourcer_db.erl
@@ -24,7 +24,7 @@
     get_uri/2
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_dump.erl
+++ b/apps/sourcer/src/sourcer_dump.erl
@@ -4,7 +4,7 @@
     dump/3
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_lsp.erl
+++ b/apps/sourcer/src/sourcer_lsp.erl
@@ -19,7 +19,7 @@
     definition/1
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_model.erl
+++ b/apps/sourcer/src/sourcer_model.erl
@@ -9,7 +9,7 @@
 
 -include("sourcer_model.hrl").
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -ifdef(DEBUG).

--- a/apps/sourcer/src/sourcer_operations.erl
+++ b/apps/sourcer/src/sourcer_operations.erl
@@ -11,7 +11,7 @@
     document_symbols/2
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_parse.erl
+++ b/apps/sourcer/src/sourcer_parse.erl
@@ -9,7 +9,7 @@
     range/1
 ]).
 
--define(DEBUG, 1).
+%%-define(DEBUG, 1).
 -include("debug.hrl").
 
 -include("sourcer_model.hrl").

--- a/apps/sourcer/src/sourcer_parse_util.erl
+++ b/apps/sourcer/src/sourcer_parse_util.erl
@@ -17,7 +17,7 @@
     take_block_list/1
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -define(k(X), {X,_,_,_}).

--- a/apps/sourcer/src/sourcer_scan.erl
+++ b/apps/sourcer/src/sourcer_scan.erl
@@ -1,6 +1,6 @@
 -module(sourcer_scan).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -export([line_info/1, split_lines/1,

--- a/apps/sourcer/src/sourcer_util.erl
+++ b/apps/sourcer/src/sourcer_util.erl
@@ -18,7 +18,7 @@
     add_auto_imported/1
 ]).
 
--define(DEBUG, true).
+%%-define(DEBUG, true).
 -include("debug.hrl").
 
 -define(SEP, ";").

--- a/rebar.config
+++ b/rebar.config
@@ -47,5 +47,6 @@
 
 {escript_main_app, erlang_ls}.
 {escript_comment, "%% v0.2.2\n"}.
+{escript_emu_args, "%%! -noinput"}. % this is for open_port in jsonrpc.erl to work
 
 {provider_hooks, [{post, [{compile, escriptize}]}]}.


### PR DESCRIPTION
Make DEBUG/TRACE optional at compilation time (off by default).  If
lsp-mode for emacs is run with sourcer in stdio mode (not tcp) then
lsp-mode will fail like on text that is not part of the proper LSP
jsonrpc texts:

    error in process filter: progn: Error parsing language server output: (error No Content-Length header)

Instead of having these (same for TRACE macros) in the source code:

    -define(DEBUG, true).
    -define(DEBUG, 1).

... use rebar3 profiles to enable DEBUG/TRACE builds.  From README.md:

    Run this to build everything:

        rebar3 compile

    Run this to build everything with `DEBUG` printouts enabled:

        rebar3 as debug compile

    Run this to build everything with `TRACE` printouts enabled:

        rebar3 as trace compile

    Run this to build everything with both `DEBUG` and `TRACE` printouts enabled:

        rebar3 as debug,trace compile

    Please note that these will result in different builds below the
    `_build` directory.